### PR TITLE
Set device class battery for SoC and SoH sensors

### DIFF
--- a/components/eg4_bms/sensor.py
+++ b/components/eg4_bms/sensor.py
@@ -7,6 +7,7 @@ from esphome.const import (
     CONF_POWER,
     CONF_TEMPERATURE,
     CONF_VOLTAGE,
+    DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_CURRENT,
     DEVICE_CLASS_ENERGY,
     DEVICE_CLASS_POWER,
@@ -190,12 +191,14 @@ CONFIG_SCHEMA = EG4_BMS_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_STATE_OF_CHARGE): sensor.sensor_schema(
             unit_of_measurement=UNIT_PERCENT,
             accuracy_decimals=0,
+            device_class=DEVICE_CLASS_BATTERY,
             state_class=STATE_CLASS_MEASUREMENT,
             icon="mdi:battery-70",
         ),
         cv.Optional(CONF_STATE_OF_HEALTH): sensor.sensor_schema(
             unit_of_measurement=UNIT_PERCENT,
             accuracy_decimals=0,
+            device_class=DEVICE_CLASS_BATTERY,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional(CONF_CYCLE_COUNT): sensor.sensor_schema(


### PR DESCRIPTION
So that they can be chosen by the new entity picker on the built-in energy dashboard.

The SoC entity picker added to the energy dashboard in home assistant 2026.6.0 [only shows entities](https://github.com/home-assistant/frontend/pull/51812/changes#diff-a863bcbc92d29ba82f48005ce07ab622b93b532ec892046c7bb1a95c9a8878f3R33) with device_class = battery. 

With this fix, the batteries exposed by this component can be chosen in that entity picker.